### PR TITLE
fix: restore v0.1.1 schemas and fix build script versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
       
       - name: Build schemas with new version
         run: npm run build:schemas
+        env:
+          RELEASE_BUILD: true
       
       - name: Run validation
         run: |

--- a/dist/schema/0.1.1/base.json
+++ b/dist/schema/0.1.1/base.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/base",
+  "title": "Design Tokens Base Schema",
+  "description": "Base schema for design tokens with JSON Schema $ref support",
+  "$comment": "DESIGN DECISIONS: 1) Uses JSON Schema $ref (url#/json/pointer) instead of DTCG's {token.path} syntax for better tooling support and standard compliance. 2) Follows DTCG token structure and types as guidance. 3) Structure: root -> groups -> leaves. Groups organize tokens, leaves hold actual values.",
+  "$ref": "#/$defs/root",
+  "$defs": {
+    "$type": {
+      "type": "string",
+      "description": "Token type identifier",
+      "enum": [
+        "color",
+        "dimension",
+        "fontFamily",
+        "fontWeight",
+        "duration",
+        "cubicBezier",
+        "number",
+        "strokeStyle",
+        "border",
+        "transition",
+        "shadow",
+        "gradient",
+        "typography"
+      ]
+    },
+    "$value": {
+      "description": "The token value - can be a direct value or a $ref",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        }
+      ]
+    },
+    "$ref": {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/$ref"
+    },
+    "$description": {
+      "type": "string",
+      "description": "Human-readable description of the token"
+    },
+    "$extensions": {
+      "type": "object",
+      "description": "Custom extensions for the token",
+      "additionalProperties": true
+    },
+    "$deprecated": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Indicates if the token is deprecated"
+    },
+    "leaf": {
+      "type": "object",
+      "description": "Base definition for all token types",
+      "properties": {
+        "$type": {
+          "$ref": "#/$defs/$type"
+        },
+        "$value": {
+          "$ref": "#/$defs/$value"
+        },
+        "$ref": {
+          "$ref": "#/$defs/$ref"
+        },
+        "$description": {
+          "$ref": "#/$defs/$description"
+        },
+        "$extensions": {
+          "$ref": "#/$defs/$extensions"
+        },
+        "$deprecated": {
+          "$ref": "#/$defs/$deprecated"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$value"
+          ],
+          "not": {
+            "required": [
+              "$ref"
+            ]
+          }
+        },
+        {
+          "required": [
+            "$ref"
+          ],
+          "not": {
+            "required": [
+              "$value"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "group": {
+      "type": "object",
+      "properties": {
+        "$description": {
+          "$ref": "#/$defs/$description"
+        },
+        "$extensions": {
+          "$ref": "#/$defs/$extensions"
+        }
+      },
+      "patternProperties": {
+        "^[^$].*": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/leaf"
+            },
+            {
+              "$ref": "#/$defs/group"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "root": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "Reference to the JSON schema"
+        },
+        "$description": {
+          "$ref": "#/$defs/$description"
+        },
+        "$extensions": {
+          "$ref": "#/$defs/$extensions"
+        }
+      },
+      "patternProperties": {
+        "^[^$].*": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/leaf"
+            },
+            {
+              "$ref": "#/$defs/group"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/dist/schema/0.1.1/border.json
+++ b/dist/schema/0.1.1/border.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/border",
+  "title": "Border Token Schema",
+  "description": "Schema for border composite tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "border"
+        },
+        "$value": {
+          "type": "object",
+          "properties": {
+            "color": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/colorValueOrRef",
+              "description": "Border color"
+            },
+            "width": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef",
+              "description": "Border width"
+            },
+            "style": {
+              "oneOf": [
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/borderStyleEnum"
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/strokeStyleObject"
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/$ref"
+                }
+              ],
+              "description": "Border style"
+            }
+          },
+          "required": [
+            "color",
+            "width",
+            "style"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/color.json
+++ b/dist/schema/0.1.1/color.json
@@ -1,0 +1,721 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/color",
+  "title": "Color Token Schema",
+  "description": "Schema for color tokens using the new color module format",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "color"
+        },
+        "$value": {
+          "type": "object",
+          "description": "Color value with explicit color space",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/srgb"
+            },
+            {
+              "$ref": "#/$defs/srgb-linear"
+            },
+            {
+              "$ref": "#/$defs/hsl"
+            },
+            {
+              "$ref": "#/$defs/hwb"
+            },
+            {
+              "$ref": "#/$defs/lab"
+            },
+            {
+              "$ref": "#/$defs/lch"
+            },
+            {
+              "$ref": "#/$defs/oklab"
+            },
+            {
+              "$ref": "#/$defs/oklch"
+            },
+            {
+              "$ref": "#/$defs/display-p3"
+            },
+            {
+              "$ref": "#/$defs/a98-rgb"
+            },
+            {
+              "$ref": "#/$defs/prophoto-rgb"
+            },
+            {
+              "$ref": "#/$defs/rec2020"
+            },
+            {
+              "$ref": "#/$defs/xyz-d65"
+            },
+            {
+              "$ref": "#/$defs/xyz-d50"
+            }
+          ]
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ],
+  "$defs": {
+    "alpha": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Alpha channel value (0-1)"
+    },
+    "hex": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$",
+      "description": "Hex color representation"
+    },
+    "componentOrNone": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "rgbBase": {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              {
+                "type": "string",
+                "const": "none"
+              }
+            ]
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "srgb": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "srgb"
+            },
+            "components": {
+              "type": "array",
+              "description": "R, G, B components (0-1)"
+            }
+          }
+        }
+      ]
+    },
+    "srgb-linear": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "srgb-linear"
+            },
+            "components": {
+              "type": "array",
+              "description": "Linear R, G, B components (0-1)"
+            }
+          }
+        }
+      ]
+    },
+    "display-p3": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "display-p3"
+            },
+            "components": {
+              "type": "array",
+              "description": "R, G, B components (0-1) in Display P3 color space"
+            }
+          }
+        }
+      ]
+    },
+    "a98-rgb": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "a98-rgb"
+            },
+            "components": {
+              "type": "array",
+              "description": "R, G, B components (0-1) in Adobe RGB (1998) color space"
+            }
+          }
+        }
+      ]
+    },
+    "prophoto-rgb": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "prophoto-rgb"
+            },
+            "components": {
+              "type": "array",
+              "description": "R, G, B components (0-1) in ProPhoto RGB color space"
+            }
+          }
+        }
+      ]
+    },
+    "rec2020": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/rgbBase"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "colorSpace": {
+              "const": "rec2020"
+            },
+            "components": {
+              "type": "array",
+              "description": "R, G, B components (0-1) in Rec.2020 color space"
+            }
+          }
+        }
+      ]
+    },
+    "hsl": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "hsl"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Hue (0-360), Saturation (0-100), Lightness (0-100)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 360
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "hwb": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "hwb"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Hue (0-360), Whiteness (0-100), Blackness (0-100)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 360
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "lab": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "lab"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Lightness (0-100), a* (-125 to 125), b* (-125 to 125)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": -125,
+                  "maximum": 125
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": -125,
+                  "maximum": 125
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "lch": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "lch"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Lightness (0-100), Chroma (0-230), Hue (0-360)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 230
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 360
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "oklab": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "oklab"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Lightness (0-1), a* (-0.4 to 0.4), b* (-0.4 to 0.4)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": -0.4,
+                  "maximum": 0.4
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": -0.4,
+                  "maximum": 0.4
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "oklch": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "oklch"
+        },
+        "components": {
+          "type": "array",
+          "description": "[Lightness (0-1), Chroma (0-0.4), Hue (0-360)]",
+          "prefixItems": [
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 0.4
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 360
+                },
+                {
+                  "type": "string",
+                  "const": "none"
+                }
+              ]
+            }
+          ],
+          "minItems": 3,
+          "maxItems": 3,
+          "items": false
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "xyz-d65": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "xyz-d65"
+        },
+        "components": {
+          "type": "array",
+          "description": "[X (0-1), Y (0-1), Z (0-1)] in CIE XYZ with D65 illuminant",
+          "items": {
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              {
+                "type": "string",
+                "const": "none"
+              }
+            ]
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    },
+    "xyz-d50": {
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "const": "xyz-d50"
+        },
+        "components": {
+          "type": "array",
+          "description": "[X (0-1), Y (0-1), Z (0-1)] in CIE XYZ with D50 illuminant",
+          "items": {
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              {
+                "type": "string",
+                "const": "none"
+              }
+            ]
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "alpha": {
+          "$ref": "#/$defs/alpha"
+        },
+        "hex": {
+          "$ref": "#/$defs/hex"
+        }
+      },
+      "required": [
+        "colorSpace",
+        "components"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/dist/schema/0.1.1/cubic-bezier.json
+++ b/dist/schema/0.1.1/cubic-bezier.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/cubic-bezier",
+  "title": "Cubic Bezier Token Schema",
+  "description": "Schema for cubic bezier tokens (animation timing functions)",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "cubicBezier"
+        },
+        "$value": {
+          "type": "array",
+          "description": "Four control points [x1, y1, x2, y2] for cubic bezier curve",
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "minItems": 4,
+          "maxItems": 4
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/dimension.json
+++ b/dist/schema/0.1.1/dimension.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/dimension",
+  "title": "Dimension Token Schema",
+  "description": "Schema for dimension tokens (spacing, sizing, etc)",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "dimension"
+        },
+        "$value": {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValue"
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/duration.json
+++ b/dist/schema/0.1.1/duration.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/duration",
+  "title": "Duration Token Schema",
+  "description": "Schema for duration tokens (animations, transitions)",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "duration"
+        },
+        "$value": {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/durationValue"
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/font-family.json
+++ b/dist/schema/0.1.1/font-family.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/font-family",
+  "title": "Font Family Token Schema",
+  "description": "Schema for font family tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "fontFamily"
+        },
+        "$value": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single font family or comma-separated list"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of font families"
+            }
+          ]
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/font-weight.json
+++ b/dist/schema/0.1.1/font-weight.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/font-weight",
+  "title": "Font Weight Token Schema",
+  "description": "Schema for font weight tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "fontWeight"
+        },
+        "$value": {
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 1000,
+              "description": "Numeric font weight value"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "thin",
+                "hairline",
+                "extra-light",
+                "ultra-light",
+                "light",
+                "normal",
+                "regular",
+                "medium",
+                "semi-bold",
+                "demi-bold",
+                "bold",
+                "extra-bold",
+                "ultra-bold",
+                "black",
+                "heavy",
+                "extra-black",
+                "ultra-black"
+              ],
+              "description": "Named font weight value"
+            }
+          ]
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/full.json
+++ b/dist/schema/0.1.1/full.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/full",
+  "title": "Full Design Tokens Schema",
+  "description": "Complete schema with all token types for full validation",
+  "$ref": "#/$defs/root",
+  "$defs": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "Reference to the JSON schema"
+        },
+        "$description": {
+          "type": "string",
+          "description": "Description of the token file"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Custom extensions",
+          "additionalProperties": true
+        }
+      },
+      "patternProperties": {
+        "^[^$].*": {
+          "$ref": "#/$defs/groupOrToken"
+        }
+      },
+      "additionalProperties": false
+    },
+    "group": {
+      "type": "object",
+      "properties": {
+        "$description": {
+          "type": "string",
+          "description": "Description of this group"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Custom extensions",
+          "additionalProperties": true
+        }
+      },
+      "patternProperties": {
+        "^[^$].*": {
+          "$ref": "#/$defs/groupOrToken"
+        }
+      },
+      "additionalProperties": false
+    },
+    "groupOrToken": {
+      "anyOf": [
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/color"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/dimension"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/font-family"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/font-weight"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/duration"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/number"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/shadow"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/typography"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/cubic-bezier"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/stroke-style"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/border"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/transition"
+        },
+        {
+          "$ref": "https://tokens.unpunny.fun/schema/0.1.1/gradient"
+        },
+        {
+          "$ref": "#/$defs/genericToken"
+        },
+        {
+          "$ref": "#/$defs/group"
+        }
+      ]
+    },
+    "genericToken": {
+      "type": "object",
+      "description": "Generic token for types not yet defined",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "description": "Token type"
+        },
+        "$value": {
+          "description": "Token value"
+        },
+        "$ref": {
+          "type": "string",
+          "pattern": "^(#(/[^/]+)*|[^#]+#(/[^/]+)*|\\./[^#]+#(/[^/]+)*)$",
+          "description": "Reference to another token"
+        },
+        "$description": {
+          "type": "string"
+        },
+        "$extensions": {
+          "type": "object"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$value"
+          ],
+          "not": {
+            "required": [
+              "$ref"
+            ]
+          }
+        },
+        {
+          "required": [
+            "$ref"
+          ],
+          "not": {
+            "required": [
+              "$value"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/dist/schema/0.1.1/gradient.json
+++ b/dist/schema/0.1.1/gradient.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/gradient",
+  "title": "Gradient Token Schema",
+  "description": "Schema for gradient composite tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "gradient"
+        },
+        "$value": {
+          "type": "array",
+          "description": "Array of color stops defining the gradient",
+          "items": {
+            "type": "object",
+            "properties": {
+              "color": {
+                "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/colorValueOrRef",
+                "description": "Color at this stop"
+              },
+              "position": {
+                "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/percentageOrRef",
+                "description": "Position of the color stop (0-1)"
+              }
+            },
+            "required": [
+              "color",
+              "position"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 2
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/number.json
+++ b/dist/schema/0.1.1/number.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/number",
+  "title": "Number Token Schema",
+  "description": "Schema for number tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "number"
+        },
+        "$value": {
+          "type": "number",
+          "description": "Numeric value"
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/resolver.json
+++ b/dist/schema/0.1.1/resolver.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/resolver",
+  "title": "Design Tokens Resolver Manifest",
+  "description": "Schema for resolver manifest files that define token composition across themes and modes",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to the JSON schema"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the resolver configuration"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of what this resolver configuration is for"
+    },
+    "sets": {
+      "type": "array",
+      "description": "Base token sets that are always loaded",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the token set"
+          },
+          "values": {
+            "type": "array",
+            "description": "Array of token file paths to load",
+            "items": {
+              "type": "string",
+              "pattern": "^[^\\s]+\\.json$"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "name",
+          "values"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "modifiers": {
+      "type": "array",
+      "description": "Modifiers that can be applied to base sets (themes, modes, etc)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the modifier dimension (e.g., 'theme', 'contrast')"
+          },
+          "values": {
+            "type": "array",
+            "description": "Possible values for this modifier",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of this modifier value (e.g., 'light', 'dark')"
+                },
+                "values": {
+                  "type": "array",
+                  "description": "Token files to apply for this modifier value",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[^\\s]+\\.json$"
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "values"
+              ],
+              "additionalProperties": false
+            },
+            "minItems": 1
+          },
+          "meta": {
+            "type": "object",
+            "description": "Additional metadata for this modifier",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "values"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "sets",
+    "modifiers"
+  ],
+  "additionalProperties": false
+}

--- a/dist/schema/0.1.1/shadow.json
+++ b/dist/schema/0.1.1/shadow.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/shadow",
+  "title": "Shadow Token Schema",
+  "description": "Schema for shadow composite tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "shadow"
+        },
+        "$value": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "color": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/colorValueOrRef"
+                },
+                "offsetX": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                },
+                "offsetY": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                },
+                "blur": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                },
+                "spread": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                },
+                "inset": {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/booleanOrRef"
+                }
+              },
+              "$comment": "Per DTCG spec: color, offsetX, offsetY, blur, spread are required. inset is optional (defaults to false)",
+              "required": [
+                "color",
+                "offsetX",
+                "offsetY",
+                "blur",
+                "spread"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "color": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/colorValueOrRef"
+                  },
+                  "offsetX": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                  },
+                  "offsetY": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                  },
+                  "blur": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                  },
+                  "spread": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef"
+                  },
+                  "inset": {
+                    "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/booleanOrRef"
+                  }
+                },
+                "$comment": "Per DTCG spec: color, offsetX, offsetY, blur, spread are required. inset is optional (defaults to false)",
+                "required": [
+                  "color",
+                  "offsetX",
+                  "offsetY",
+                  "blur",
+                  "spread"
+                ],
+                "additionalProperties": false
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/stroke-style.json
+++ b/dist/schema/0.1.1/stroke-style.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/stroke-style",
+  "title": "Stroke Style Token Schema",
+  "description": "Schema for stroke style tokens (line/border styles)",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "strokeStyle"
+        },
+        "$value": {
+          "oneOf": [
+            {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/borderStyleEnum"
+            },
+            {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/strokeStyleObject"
+            }
+          ]
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/transition.json
+++ b/dist/schema/0.1.1/transition.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/transition",
+  "title": "Transition Token Schema",
+  "description": "Schema for transition composite tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "transition"
+        },
+        "$value": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "oneOf": [
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/durationValue"
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/$ref"
+                }
+              ],
+              "description": "Transition duration"
+            },
+            "delay": {
+              "oneOf": [
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/durationValue"
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/$ref"
+                }
+              ],
+              "description": "Transition delay"
+            },
+            "timingFunction": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "description": "Cubic bezier control points",
+                  "items": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/$ref"
+                }
+              ],
+              "description": "Transition timing function"
+            }
+          },
+          "required": [
+            "duration",
+            "delay",
+            "timingFunction"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/typography.json
+++ b/dist/schema/0.1.1/typography.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/typography",
+  "title": "Typography Token Schema",
+  "description": "Schema for typography composite tokens",
+  "allOf": [
+    {
+      "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/leaf"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "$type": {
+          "type": "string",
+          "const": "typography"
+        },
+        "$value": {
+          "type": "object",
+          "$comment": "Per DTCG spec: All properties are required for typography tokens",
+          "properties": {
+            "fontFamily": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "$ref": "https://tokens.unpunny.fun/schema/0.1.1/base#/$defs/$ref"
+                }
+              ],
+              "description": "Font family name or stack"
+            },
+            "fontSize": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef",
+              "description": "Font size in px or rem"
+            },
+            "fontWeight": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/fontWeightValueOrRef",
+              "description": "Font weight (numeric 1-1000 or keyword)"
+            },
+            "lineHeight": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/lineHeightValueOrRef",
+              "$comment": "DTCG spec: lineHeight is a multiplier of fontSize, not a dimension",
+              "description": "Line height as multiplier of font size (typically 0.5-3)"
+            },
+            "letterSpacing": {
+              "$ref": "https://tokens.unpunny.fun/schema/0.1.1/value-types#/$defs/dimensionValueOrRef",
+              "description": "Horizontal spacing between characters"
+            }
+          },
+          "required": [
+            "fontFamily",
+            "fontSize",
+            "fontWeight",
+            "lineHeight",
+            "letterSpacing"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "$type"
+      ]
+    }
+  ]
+}

--- a/dist/schema/0.1.1/value-types.json
+++ b/dist/schema/0.1.1/value-types.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tokens.unpunny.fun/schema/0.1.1/value-types",
+  "title": "Design Token Value Types",
+  "description": "Shared value type definitions for design tokens - no dependencies",
+  "$comment": "This schema contains all shared value types and helpers used across different token types. It has NO dependencies on other schemas to avoid circular references.",
+  "$defs": {
+    "$ref": {
+      "type": "string",
+      "description": "Reference to another token using JSON Pointer syntax",
+      "pattern": "^(#(/[^/]+)*|[^#]+#(/[^/]+)*|\\./[^#]+#(/[^/]+)*)$",
+      "$comment": "Supports: 1) Internal refs (#/path/to/token), 2) External refs (file.json#/path), 3) Relative refs (./file.json#/path)"
+    },
+    "dimensionUnits": {
+      "description": "Valid DTCG dimension units per spec",
+      "enum": [
+        "px",
+        "rem"
+      ]
+    },
+    "dimensionValue": {
+      "description": "A dimension value with unit per DTCG spec",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^-?\\d+(\\.\\d+)?(px|rem)$"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "number"
+            },
+            "unit": {
+              "$ref": "#/$defs/dimensionUnits"
+            }
+          },
+          "required": [
+            "value",
+            "unit"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "dimensionValueOrRef": {
+      "description": "Dimension value (string with unit or number) or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "durationUnits": {
+      "description": "Time units for durations",
+      "enum": [
+        "ms",
+        "s"
+      ]
+    },
+    "durationValue": {
+      "description": "A duration value with unit",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(ms|s)$"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "number",
+              "minimum": 0
+            },
+            "unit": {
+              "$ref": "#/$defs/durationUnits"
+            }
+          },
+          "required": [
+            "value",
+            "unit"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "colorValueOrRef": {
+      "description": "Color value (string) or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "numberOrRef": {
+      "description": "Number or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "percentageOrRef": {
+      "description": "Percentage value (0-1) or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "fontWeightValue": {
+      "description": "Font weight value (1-1000 or keyword)",
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        {
+          "type": "string",
+          "enum": [
+            "thin",
+            "hairline",
+            "extra-light",
+            "ultra-light",
+            "light",
+            "normal",
+            "regular",
+            "medium",
+            "semi-bold",
+            "demi-bold",
+            "bold",
+            "extra-bold",
+            "ultra-bold",
+            "black",
+            "heavy",
+            "extra-black",
+            "ultra-black"
+          ]
+        }
+      ]
+    },
+    "fontWeightValueOrRef": {
+      "description": "Font weight value or reference to a token's value",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/fontWeightValue"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "lineHeightValue": {
+      "description": "Line height multiplier (typically 0.5-3)",
+      "type": "number",
+      "minimum": 0.5,
+      "maximum": 3,
+      "$comment": "While any positive number is technically valid, practical values are typically between 0.5 and 3"
+    },
+    "lineHeightValueOrRef": {
+      "description": "Line height value or reference to a token's value",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/lineHeightValue"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "stringOrRef": {
+      "description": "String or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "booleanOrRef": {
+      "description": "Boolean or reference to a token's value",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/$defs/$ref"
+            }
+          },
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "borderStyleEnum": {
+      "description": "Standard border/stroke styles",
+      "enum": [
+        "solid",
+        "dashed",
+        "dotted",
+        "double",
+        "groove",
+        "ridge",
+        "outset",
+        "inset"
+      ]
+    },
+    "lineCapEnum": {
+      "description": "Line cap styles for strokes",
+      "enum": [
+        "round",
+        "butt",
+        "square"
+      ]
+    },
+    "strokeStyleObject": {
+      "description": "Custom stroke style with dash pattern",
+      "type": "object",
+      "properties": {
+        "dashArray": {
+          "type": "array",
+          "description": "Array of dimension values defining dash pattern",
+          "items": {
+            "$ref": "#/$defs/dimensionValueOrRef"
+          }
+        },
+        "lineCap": {
+          "$ref": "#/$defs/lineCapEnum"
+        }
+      },
+      "required": [
+        "dashArray"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
- Restore deleted 0.1.1 schema files from v0.1.1 tag
- Fix build script to preserve old version folders
- Only clean latest and *-dev folders during builds
- Use RELEASE_BUILD env var for proper version detection in releases
- Prevents future releases from deleting historical versions